### PR TITLE
Adding the new class

### DIFF
--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -43,6 +43,7 @@
 #endif
 #include "aJSON.h"
 #include "utility/stringbuffer.h"
+#include <stdio.h>
 
 /******************************************************************************
  * Definitions
@@ -81,6 +82,7 @@ aJsonStream::getch()
       bucket = EOF;
       return ret;
     }
+
   // In case input was malformed - can happen, this is the
   // real world, we can end up in a situation where the parser
   // would expect another character and end up stuck on
@@ -95,6 +97,22 @@ aJsonStream::ungetch(char ch)
 {
   bucket = ch;
 }
+
+
+int
+aJsonFileStream::getch()
+{
+  if (bucket != EOF)
+    {
+      int ret = bucket;
+      bucket = EOF;
+      return ret;
+    }
+  return fgetc(fl);
+}
+
+
+
 
 size_t
 aJsonStream::write(uint8_t ch)

--- a/aJSON.h
+++ b/aJSON.h
@@ -167,6 +167,20 @@ private:
 	size_t inbuf_len, outbuf_len;
 };
 
+class aJsonFileStream : public aJsonStream {
+public:
+        aJsonFileStream(FILE* _fl)
+                : aJsonStream(NULL)
+        {
+                fl=_fl;
+        }
+
+
+private:
+        virtual int getch();
+        FILE* fl;
+};
+
 class aJsonClass {
 	/******************************************************************************
 	 * Constructors


### PR DESCRIPTION
adding class "aJsonFileStream" inherited from  aJsonStream in order to backward- compatibility with HTTPClient library
Now is possible to operate directly with *FILE like streams, returned by HttpClient library and avoid intermediate buffering

Code example:

```
int getConfig()
{
    FILE* result;
    int returnCode ;

    HTTPClient hclient("192.168.88.2",hserver,80);
    result = hclient.getURI( FEED_URI);
    returnCode = hclient.getLastReturnCode();

    if (result!=NULL) {
      if (returnCode==200) {

          Serial.println("got Config :"); 
             aJsonFileStream as=aJsonFileStream(result);  
          root = aJson.parse(&as);

     hclient.closeStream(result);  // this is very important -- be sure to close the STREAM

        if (!root)
          {
            Serial.println("parseObject() failed");
           return -11;
            } else   

          {

            char * outstr=aJson.print(root);
            Serial.println(outstr);
             items = aJson.getObjectItem(root,"items");            
          }

            } 
    else {
      Serial.print("ERROR: Server returned ");
      Serial.println(returnCode);
      return -11;

    }

    } 
    else {
      Serial.println("failed to connect");
      Serial.println(" try again in 5 seconds");
      return -11;
                }



  return 2;
}

```
